### PR TITLE
(refactor): unset  app instance specific env

### DIFF
--- a/experiments/chaostoolkit/k8-pod-delete/k8-pod-delete_job.yml
+++ b/experiments/chaostoolkit/k8-pod-delete/k8-pod-delete_job.yml
@@ -19,14 +19,14 @@ spec:
         imagePullPolicy: Always
         env:
           - name: FILE
-            value: 'experiment.json'
+            value: 'pod-app-kill-count.json'
 
           - name: LABEL_NAME
-            value: 'nginx'
+            value: ''
 
           # provide application namespace
           - name: NAME_SPACE
-            value: 'default'
+            value: ''
 
           # provide application labels
           - name: APP_ENDPOINT
@@ -34,7 +34,10 @@ spec:
 
           # provide application labels
           - name: PERCENTAGE
-            value: '50'            
+            value: '50'           
+
+          - name: CHAOSTOOLKIT_IN_POD
+            value: "true" 
 
           ## env var that describes the library used to execute the chaos
           ## default: litmus. Supported values: litmus, powerfulseal, chaostoolkit
@@ -50,4 +53,4 @@ spec:
                 fieldPath: spec.serviceAccountName
 
         command: ["/bin/bash"]
-        args: ["-c", "python /app/data/k8_wrapper.py ; exit 0"]
+        args: ["-c", "python /app/data/k8_wrapper.py; exit 0"]


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Makes the job spec consistent with other experiments in the litmus repo by removing app instance info
- Uses `pod-app-kill-count.json` as a default spec for chaos
- Uses the CHAOSTOOLKIT_IN_POD as per chaostoolkit documentation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
